### PR TITLE
Address lack of environment variables in `tmux` status bar script

### DIFF
--- a/dotfiles_OpenBSD/xsession
+++ b/dotfiles_OpenBSD/xsession
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-export LANG=en_US.UTF-8
-export LC_CTYPE=en_US.UTF-8
-export ENV="${HOME}/.kshrc"
+LANG=en_US.UTF-8
+LC_CTYPE=en_US.UTF-8
+ENV="${HOME}/.kshrc"
+SHELL="/usr/bin/tmux"
+export LANG LC_CTYPE ENV SHELL
 
 # No bell
 xset b 0 0 0


### PR DESCRIPTION
* If/until such can be set in .tmux.conf, provide alternatives for missing environment variables
* Clean-up status bar to save space and display more information
* Throw-in having `tmux` as the default SHELL for `xterm`