### PR TITLE
Add `frotz` z-machine emulator on macOS and `clamav` on OpenBSD

### DIFF
--- a/bin_Darwin/configure_Darwin.sh
+++ b/bin_Darwin/configure_Darwin.sh
@@ -137,6 +137,7 @@ then
 		act
 		awscli
 		azure-cli
+		frotz
 		go
 		hadolint
 		hashicorp/tap/terraform

--- a/bin_OpenBSD/configure_OpenBSD.sh
+++ b/bin_OpenBSD/configure_OpenBSD.sh
@@ -69,6 +69,7 @@ cmp -s /etc/sysctl.conf "${HOME}/dotfiles/config_OpenBSD/sysctl.conf" || {
 
 readonly packages="abcde
 chromium
+clamav
 curl
 flac
 ffmpeg
@@ -88,3 +89,8 @@ yt-dlp"
 # shellcheck disable=SC2046
 doas pkg_add $(printf '%s' "${packages}" | tr '\n' ' ')
 
+#
+# ClamAV
+#
+
+# To-do: configure clamav to auto-update


### PR DESCRIPTION
* Add the z-machine emulator `frotz` on macOS (already on OpenBSD)
* Add `clamav` on OpenBSD for scanning downloaded files