### PR TITLE
Add CWM binding for app.logos.com in dedicated window

### DIFF
--- a/dotfiles_OpenBSD/cwmrc
+++ b/dotfiles_OpenBSD/cwmrc
@@ -18,4 +18,5 @@ command xterm xterm
 
 bind-key CMS-w		openbsd-wallpaper
 bind-key CM-b		firefox
+bind-key CM-l		chrome app.logos.com
 


### PR DESCRIPTION
Would like to improve this later, but this works for now!

Fulfills #21 